### PR TITLE
Swap ElevenLabs SDK for @speech-sdk/core and add a provider picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ To run this application locally, kindly follow the steps below:
 
 5. All good! You can start modifying any page and the app will auto-update.
 
+### Speech providers
+
+As of this version, text-to-speech is powered by
+[`@speech-sdk/core`](https://www.npmjs.com/package/@speech-sdk/core), a unified
+multi-provider TTS SDK. Two providers ship out of the box:
+
+- **ElevenLabs** (default) — set `ELEVENLABS_API_KEY`
+- **OpenAI** — set `OPENAI_API_KEY` (reuses the key already required for chat
+  completions)
+
+You can switch providers at runtime using the "Speech Provider" dropdown in the
+chat UI. Your selection is persisted to `localStorage`. ElevenLabs voices are
+fetched dynamically via the ElevenLabs API; OpenAI voices are the fixed catalog
+(`alloy`, `ash`, `ballad`, `coral`, `echo`, `fable`, `nova`, `onyx`, `sage`,
+`shimmer`).
+
+To add a new provider, append it to `app/utils/providers.ts` and add a case in
+`app/api/speech/route.ts`. `@speech-sdk/core` supports Deepgram, Cartesia,
+Hume, Google, and others via subpath imports.
+
 ## API Keys Guide
 
 To enable anyone to test the application in production if they want to, I've added a form where they can enter their API keys for both OpenAI and ElevenLabs (so I don't have to cover the costs and deal with request overload since this is a basic demo for now). This is a good way for anyone to test the application without having to clone and run it locally. To create both API keys (if you don't have one already), **kindly read this section of [the tutorial](https://blog.bolajiayodeji.com/how-to-build-an-audio-chatbot-with-nextjs-openai-and-elevenlabs#heading-setting-up-openai)**. Once you have the keys, click on the settings icon at the top section of the page, and enter them in the form provided. You can repeat the same process to update the keys.

--- a/app/api/speech/route.ts
+++ b/app/api/speech/route.ts
@@ -1,28 +1,54 @@
-import { ElevenLabsClient } from "elevenlabs";
+import { generateSpeech } from "@speech-sdk/core";
+import { createElevenLabs } from "@speech-sdk/core/elevenlabs";
+import { createOpenAI } from "@speech-sdk/core/openai";
+import { DEFAULT_PROVIDER, SpeechProviderId } from "@/app/utils/providers";
 
 const isProduction = process.env.NEXT_PUBLIC_APP_MODE === "production";
 
-export async function POST(req: Request) {
-  const { apiKey, message, voice } = await req.json();
+function resolveModel(provider: SpeechProviderId, apiKey: string | undefined) {
+  // In production, the client-supplied key is used (BYO-key flow).
+  // In dev, the server falls back to env so the live demo works without keys.
+  switch (provider) {
+    case "openai": {
+      const key = isProduction ? apiKey : process.env.OPENAI_API_KEY;
+      return createOpenAI({ apiKey: key })("tts-1");
+    }
+    case "elevenlabs": {
+      const key = isProduction ? apiKey : process.env.ELEVENLABS_API_KEY;
+      // eleven_turbo_v2 matches the upstream model choice for latency parity.
+      return createElevenLabs({ apiKey: key })("eleven_turbo_v2");
+    }
+    default: {
+      // Exhaustiveness check — TS will flag new providers that forget a case.
+      const _never: never = provider;
+      throw new Error(`Unknown speech provider: ${_never}`);
+    }
+  }
+}
 
-  const elevenlabs = new ElevenLabsClient({
-    apiKey: isProduction ? apiKey : process.env.ELEVENLABS_API_KEY
-  });
+export async function POST(req: Request) {
+  const { apiKey, message, voice, provider } = await req.json();
+  const resolvedProvider: SpeechProviderId = provider ?? DEFAULT_PROVIDER;
 
   try {
-    const audio = await elevenlabs.generate({
-      voice,
-      model_id: "eleven_turbo_v2",
-      voice_settings: { similarity_boost: 0.5, stability: 0.5 },
-      text: message
-      // stream: true,
+    const model = resolveModel(resolvedProvider, apiKey);
+    const result = await generateSpeech({
+      model,
+      text: message,
+      voice
     });
 
-    return new Response(audio as any, {
-      headers: { "Content-Type": "audio/mpeg" }
+    return new Response(result.audio.uint8Array as any, {
+      headers: { "Content-Type": result.audio.mediaType }
     });
   } catch (error: any) {
     console.error(error);
-    return Response.json(error, { status: error.statusCode });
+    // @speech-sdk/core throws ApiError with .statusCode for upstream HTTP failures.
+    const status =
+      typeof error?.statusCode === "number" ? error.statusCode : 500;
+    return Response.json(
+      { error: error?.message ?? "Speech generation failed" },
+      { status }
+    );
   }
 }

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -22,6 +22,7 @@ export default function ChatPage() {
   const [openAiKey, setOpenAiKey] = useLocalStorage<string>("openai-key", "");
   const [elevenLabsKey, setElevenLabsKey] = useLocalStorage<string>("11labs-key", "");
   const [voices, setVoices] = useState<ProviderVoice[]>([]);
+  const [voicesLoading, setVoicesLoading] = useState<boolean>(true);
   const [selectedProvider, setSelectedProvider] =
     useLocalStorage<SpeechProviderId>("selectedProvider", DEFAULT_PROVIDER);
   const [selectedVoice, setSelectedVoice] = useLocalStorage<string>(
@@ -117,6 +118,7 @@ export default function ChatPage() {
 
   useEffect(() => {
     let cancelled = false;
+    setVoicesLoading(true);
     getVoices(selectedProvider)
       .then((fetched) => {
         if (cancelled) return;
@@ -130,6 +132,9 @@ export default function ChatPage() {
       })
       .catch((error) => {
         console.error("Error fetching voices:", error);
+      })
+      .finally(() => {
+        if (!cancelled) setVoicesLoading(false);
       });
     return () => {
       cancelled = true;
@@ -141,7 +146,7 @@ export default function ChatPage() {
 
   return (
     <main className="flex flex-col min-h-screen items-center justify-between py-4 px-4 lg:px-0">
-      {voices.length === 0 ? (
+      {voicesLoading ? (
         <p className="text-white text-9xl animate-ping">...</p>
       ) : (
         <>

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -9,16 +9,25 @@ import ChatInput from "@/app/components/chatInput";
 import useLocalStorage from "@/app/hooks/useLocalStorage";
 import getVoices from "@/app/utils/getVoices";
 import notifyUser from "@/app/utils/notifyUser";
-import { userRole, botRole, Message } from "@/app/types/chat";
-import { Voice as VoiceResponse } from "elevenlabs/api";
+import { userRole, botRole, Message, ProviderVoice } from "@/app/types/chat";
+import {
+  DEFAULT_PROVIDER,
+  SpeechProviderId,
+  getProviderDef
+} from "@/app/utils/providers";
 
 export default function ChatPage() {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isModal, setIsModal] = useState(false);
   const [openAiKey, setOpenAiKey] = useLocalStorage<string>("openai-key", "");
   const [elevenLabsKey, setElevenLabsKey] = useLocalStorage<string>("11labs-key", "");
-  const [voices, setVoices] = useState<VoiceResponse[]>([]);
-  const [selectedVoice, setSelectedVoice] = useLocalStorage<string>("selectedVoice", "Myra");
+  const [voices, setVoices] = useState<ProviderVoice[]>([]);
+  const [selectedProvider, setSelectedProvider] =
+    useLocalStorage<SpeechProviderId>("selectedProvider", DEFAULT_PROVIDER);
+  const [selectedVoice, setSelectedVoice] = useLocalStorage<string>(
+    "selectedVoice",
+    "Myra"
+  );
   const [input, setInput] = useState("");
   const [messages, setMessages] = useLocalStorage<Message[]>("chatMessages", []);
   const [loading, setLoading] = useState<boolean>(false);
@@ -44,21 +53,23 @@ export default function ChatPage() {
     return data;
   };
 
-  const getElevenLabsResponse = async (text: string) => {
+  const getSpeechResponse = async (text: string) => {
     const response = await fetch("/api/speech", {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
       },
       body: JSON.stringify({
-        apiKey: elevenLabsKey,
+        apiKey: selectedProvider === "openai" ? openAiKey : elevenLabsKey,
         message: text,
-        voice: selectedVoice
+        voice: selectedVoice,
+        provider: selectedProvider
       })
     });
 
     if (response.status === 401) {
-      notifyUser("Your ElevenLabs API Key is invalid. Kindly check and try again.", {
+      const label = selectedProvider === "openai" ? "OpenAI" : "ElevenLabs";
+      notifyUser(`Your ${label} API Key is invalid. Kindly check and try again.`, {
         type: "error",
         autoClose: 5000
       });
@@ -82,7 +93,7 @@ export default function ChatPage() {
       setMessages(chatMessages);
 
       const botChatResponse = await getOpenAIResponse(chatMessages);
-      const botVoiceResponse = await getElevenLabsResponse(botChatResponse);
+      const botVoiceResponse = await getSpeechResponse(botChatResponse);
 
       const reader = new FileReader();
       reader.readAsDataURL(botVoiceResponse);
@@ -105,14 +116,28 @@ export default function ChatPage() {
   };
 
   useEffect(() => {
-    getVoices()
-      .then((voices) => {
-        setVoices(voices ?? []);
+    let cancelled = false;
+    getVoices(selectedProvider)
+      .then((fetched) => {
+        if (cancelled) return;
+        setVoices(fetched);
+        // If the current selection isn't in the new provider's catalog,
+        // snap to the provider's default voice.
+        const hasCurrent = fetched.some((v) => v.id === selectedVoice);
+        if (!hasCurrent) {
+          setSelectedVoice(getProviderDef(selectedProvider).defaultVoice);
+        }
       })
       .catch((error) => {
         console.error("Error fetching voices:", error);
       });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+    // selectedVoice intentionally omitted: we don't want to refetch when the
+    // user picks a different voice within the same provider.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProvider]);
 
   return (
     <main className="flex flex-col min-h-screen items-center justify-between py-4 px-4 lg:px-0">
@@ -129,7 +154,15 @@ export default function ChatPage() {
                 setElevenLabsKey
               }}
             />
-            <ChatVoice {...{ voices, selectedVoice, setSelectedVoice }} />
+            <ChatVoice
+              {...{
+                voices,
+                selectedVoice,
+                setSelectedVoice,
+                selectedProvider,
+                setSelectedProvider
+              }}
+            />
           </div>
           <ChatMessages {...{ messages }} />
           <div className="flex flex-col items-center w-full fixed bottom-0 pb-3 bg-gray-900">

--- a/app/components/chatVoice.tsx
+++ b/app/components/chatVoice.tsx
@@ -1,28 +1,58 @@
 import { ChatVoiceProps } from "@/app/types/chat";
+import { SPEECH_PROVIDERS, SpeechProviderId } from "@/app/utils/providers";
 
-export default function ChatVoice({ voices, selectedVoice, setSelectedVoice }: ChatVoiceProps) {
+export default function ChatVoice({
+  voices,
+  selectedVoice,
+  setSelectedVoice,
+  selectedProvider,
+  setSelectedProvider
+}: ChatVoiceProps) {
   return (
     <>
-      <div className="p-4 lg:p-8 lg:w-3/4 xl:w-2/4 border-0 lg:border-x-2 lg:border-white">
-        <label className="mb-2 block text-sm lg:text-base" htmlFor="voices">
-          Change Siri&apos;s Voice:
-        </label>
-        <select
-          id="voices"
-          name="voices"
-          className="p-2 w-4/4 text-sm lg:text-base appearance-none bg-transparent border border-white text-blue-500"
-          value={selectedVoice}
-          onChange={(event) => setSelectedVoice(event.target.value)}
-        >
-          {voices &&
-            voices
-              .sort((a, b) => a.name!.localeCompare(b.name!))
+      <div className="p-4 lg:p-8 lg:w-3/4 xl:w-2/4 border-0 lg:border-x-2 lg:border-white flex flex-col lg:flex-row gap-4">
+        <div className="flex-1">
+          <label className="mb-2 block text-sm lg:text-base" htmlFor="provider">
+            Speech Provider:
+          </label>
+          <select
+            id="provider"
+            name="provider"
+            className="p-2 w-full text-sm lg:text-base appearance-none bg-transparent border border-white text-blue-500"
+            value={selectedProvider}
+            onChange={(event) =>
+              setSelectedProvider(event.target.value as SpeechProviderId)
+            }
+          >
+            {SPEECH_PROVIDERS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="mb-2 block text-sm lg:text-base" htmlFor="voices">
+            Change Siri&apos;s Voice:
+          </label>
+          <select
+            id="voices"
+            name="voices"
+            className="p-2 w-full text-sm lg:text-base appearance-none bg-transparent border border-white text-blue-500"
+            value={selectedVoice}
+            onChange={(event) => setSelectedVoice(event.target.value)}
+          >
+            {voices
+              .slice()
+              .sort((a, b) => a.name.localeCompare(b.name))
               .map((voice) => (
-                <option key={voice.voice_id} value={voice.name}>
-                  {voice.name} ({voice.labels?.age} {voice.labels?.accent} {voice.labels?.gender})
+                <option key={voice.id} value={voice.id}>
+                  {voice.name}
+                  {voice.description ? ` (${voice.description})` : ""}
                 </option>
               ))}
-        </select>
+          </select>
+        </div>
       </div>
       <hr className="w-full lg:w-3/4 xl:w-2/4" />
     </>

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -1,4 +1,4 @@
-import { Voice as VoiceResponse } from "elevenlabs/api";
+import { SpeechProviderId } from "@/app/utils/providers";
 
 export const userRole = "user";
 export const botRole = "assistant";
@@ -15,10 +15,19 @@ export interface StoreApiKeysProps {
   setElevenLabsKey: (voice: string) => void;
 }
 
+/** Normalized voice shape used across providers in the UI. */
+export interface ProviderVoice {
+  id: string;
+  name: string;
+  description?: string;
+}
+
 export interface ChatVoiceProps {
-  voices: VoiceResponse[];
+  voices: ProviderVoice[];
   selectedVoice: string;
   setSelectedVoice: (voice: string) => void;
+  selectedProvider: SpeechProviderId;
+  setSelectedProvider: (provider: SpeechProviderId) => void;
 }
 
 export interface ChatMessagesProps {

--- a/app/utils/getVoices.ts
+++ b/app/utils/getVoices.ts
@@ -1,18 +1,41 @@
 "use server";
 
 import { ElevenLabsClient } from "elevenlabs";
+import {
+  SpeechProviderId,
+  getProviderDef
+} from "@/app/utils/providers";
+import { ProviderVoice } from "@/app/types/chat";
 
-export default async function getVoices() {
-  const elevenlabs = new ElevenLabsClient({
-    // Use the API key from env in production
-    // So the voices are available on first render.
-    apiKey: process.env.ELEVENLABS_API_KEY
-  });
-
-  try {
-    const allVoices = await elevenlabs.voices.getAll();
-    return allVoices.voices;
-  } catch (error) {
-    console.error(error);
+export default async function getVoices(
+  provider: SpeechProviderId = "elevenlabs"
+): Promise<ProviderVoice[]> {
+  if (provider === "elevenlabs") {
+    try {
+      const elevenlabs = new ElevenLabsClient({
+        // Use the API key from env in production
+        // So the voices are available on first render.
+        apiKey: process.env.ELEVENLABS_API_KEY
+      });
+      const allVoices = await elevenlabs.voices.getAll();
+      return (allVoices.voices ?? []).map((v) => {
+        const labels = [v.labels?.age, v.labels?.accent, v.labels?.gender]
+          .filter(Boolean)
+          .join(" ");
+        return {
+          // ElevenLabs is queried by voice name downstream, so use name as id.
+          id: v.name ?? v.voice_id ?? "",
+          name: v.name ?? "Unnamed",
+          description: labels || undefined
+        };
+      });
+    } catch (error) {
+      console.error(error);
+      return [];
+    }
   }
+
+  // Static-catalog providers (e.g. OpenAI).
+  const def = getProviderDef(provider);
+  return (def.voices ?? []).map((v) => ({ id: v.id, name: v.name }));
 }

--- a/app/utils/providers.ts
+++ b/app/utils/providers.ts
@@ -1,0 +1,55 @@
+// Speech provider registry. Adding a provider should only require
+// appending to this list and adding a case in /api/speech.
+
+export type SpeechProviderId = "elevenlabs" | "openai";
+
+export interface SpeechProviderStaticVoice {
+  id: string;
+  name: string;
+}
+
+export interface SpeechProviderDef {
+  id: SpeechProviderId;
+  label: string;
+  // Default voice id when user first switches to this provider.
+  defaultVoice: string;
+  // Static voice catalog for providers whose voices are fixed (OpenAI TTS).
+  // Omitted when voices are fetched dynamically (ElevenLabs).
+  voices?: SpeechProviderStaticVoice[];
+}
+
+export const SPEECH_PROVIDERS: SpeechProviderDef[] = [
+  {
+    id: "elevenlabs",
+    label: "ElevenLabs",
+    // Matches the upstream default in app/chat/page.tsx.
+    defaultVoice: "Myra"
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    defaultVoice: "alloy",
+    voices: [
+      { id: "alloy", name: "Alloy" },
+      { id: "ash", name: "Ash" },
+      { id: "ballad", name: "Ballad" },
+      { id: "coral", name: "Coral" },
+      { id: "echo", name: "Echo" },
+      { id: "fable", name: "Fable" },
+      { id: "nova", name: "Nova" },
+      { id: "onyx", name: "Onyx" },
+      { id: "sage", name: "Sage" },
+      { id: "shimmer", name: "Shimmer" }
+    ]
+  }
+];
+
+export const DEFAULT_PROVIDER: SpeechProviderId = "elevenlabs";
+
+export function getProviderDef(id: SpeechProviderId): SpeechProviderDef {
+  const def = SPEECH_PROVIDERS.find((p) => p.id === id);
+  if (!def) {
+    throw new Error(`Unknown speech provider: ${id}`);
+  }
+  return def;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chat-with-siri",
       "version": "0.1.0",
       "dependencies": {
+        "@speech-sdk/core": "^0.4.1",
         "@vercel/analytics": "^1.1.4",
         "elevenlabs": "^1.59.0",
         "next": "^16.2.0",
@@ -2475,6 +2476,15 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@speech-sdk/core": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@speech-sdk/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-kmZNI8nK3uHsfkxkhNT89ZmCzmAF4ID0A1ttj+oVvfX8JUfwVRXoY7+YKUnwEaU6WEAPsTcw97t6m3jGJmHNJg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-retry": "^8.0.0"
+      }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -6283,6 +6293,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7409,6 +7431,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@speech-sdk/core": "^0.4.1",
     "@vercel/analytics": "^1.1.4",
     "elevenlabs": "^1.59.0",
     "next": "^16.2.0",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## What I did

Replaces the direct `elevenlabs` SDK integration in `/api/speech` with [`@speech-sdk/core`](https://www.npmjs.com/package/@speech-sdk/core) — a unified, multi-provider text-to-speech SDK — and adds a **Speech Provider** dropdown next to the existing voice picker so users can switch between TTS backends at runtime.

**Concretely:**

- Added `@speech-sdk/core` dependency (`^0.4.1`)
- New provider registry at `app/utils/providers.ts` — single source of truth for supported providers (currently ElevenLabs + OpenAI) with static voice catalogs where applicable
- `/api/speech` now constructs a `ResolvedModel` via `createElevenLabs` / `createOpenAI` and calls `generateSpeech({ model, text, voice })`; responds with the SDK-reported `mediaType` instead of hardcoding `audio/mpeg`
- `getVoices(provider)` accepts a provider arg and returns a normalized `ProviderVoice` shape — ElevenLabs voices stay dynamic (via the ElevenLabs voices API), OpenAI uses the static catalog (alloy / ash / ballad / coral / echo / fable / nova / onyx / sage / shimmer)
- `ChatVoice` renders two `<select>`s (provider + voice). Provider + voice are persisted to `localStorage`; switching provider auto-snaps `selectedVoice` to that provider's default when the prior selection isn't in the new catalog
- Fixed a latent bug surfaced by the provider change: the chat page was gated on `voices.length === 0` as a loading indicator, which caused the UI to hang forever if the ElevenLabs key lacked `voices_read` scope. Replaced with an explicit `voicesLoading` flag that flips off after the first fetch attempt (success *or* failure), so users can always reach the provider dropdown and switch backends
- Updated README with a "Speech providers" section documenting the dropdown, the two built-in providers, and how to add more

**ElevenLabs remains the default** so behavior at `chat-with-siri.vercel.app` is unchanged for anyone who doesn't touch the new dropdown.

**Minor behavior change to call out:** the previous route passed `voice_settings: { similarity_boost: 0.5, stability: 0.5 }` to ElevenLabs directly. `@speech-sdk/core` uses provider defaults; these can be reintroduced via `providerOptions` if you'd like them back — happy to add that in a follow-up commit if you prefer.

Closes: <!-- Happy to open a tracking issue if you'd prefer one — opening the PR directly since the diff is small and self-contained -->

## How to test

```bash
git checkout <this-branch>
npm install
cp .env.example .env.local
# add OPENAI_API_KEY and ELEVENLABS_API_KEY
npm run dev
```

Then at `http://localhost:3000/chat`:

1. **ElevenLabs regression check** — provider dropdown defaults to "ElevenLabs", voice list populates dynamically, sending a message plays audio. Behavior should be identical to `main`.
2. **OpenAI path** — switch the provider dropdown to "OpenAI". The voice dropdown swaps to the 10 static OpenAI voices, selection snaps to `alloy`. Send a message — audio plays via OpenAI TTS (`tts-1`).
3. **Persistence** — reload the page; provider + voice selection survives via `localStorage`.
4. **Error surface** — temporarily break one of the keys; the toast shows the correct provider name ("Your OpenAI API Key is invalid…" vs ElevenLabs).

`npx tsc --noEmit` is clean and `npm run build` passes.

## Any background context you want to add?

- `@speech-sdk/core` is an open-source, MIT-licensed multi-provider TTS SDK — repo at [Jellypod-Inc/speech-sdk](https://github.com/Jellypod-Inc/speech-sdk). Full disclosure: I'm one of the maintainers, which is part of why I was interested in this swap — `chat-with-siri`'s architecture (single ElevenLabs integration with a voice picker) is exactly the shape the SDK abstracts cleanly, and it was a good real-world test. No hard feelings if you'd rather not take the dependency.
- Adding more providers (Deepgram, Cartesia, Hume, Google, Fish Audio, xAI, etc.) is now a two-line change: append to `SPEECH_PROVIDERS` in `app/utils/providers.ts` and add a case in `app/api/speech/route.ts`. I kept it to ElevenLabs + OpenAI in this PR to minimize review surface.
- I deliberately did **not** touch `/api/chat`, the API-key modal, styling, or any unrelated code — scoped the PR tightly per your contributor guide.
- No tests added because the repo has no test harness and introducing one felt out of scope. Happy to add a vitest setup in a separate PR if you'd find that useful.